### PR TITLE
Move GPG signing to deploy phase to fix CI build issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and uses [Semantic Versioning](https://semver.org/).
 
+### [Unreleased]
+#### Chore
+- Move GPG signing to deploy phase to prevent CI failures
+
 ### [v1.0.0-alpha] - 2025-07-15
 #### Changed
 - Changed `pom`.

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
-                        <phase>verify</phase>
+                        <phase>deploy</phase>
                         <goals>
                             <goal>sign</goal>
                         </goals>


### PR DESCRIPTION
### 🔧 What was changed
Moved the GPG signing execution from the `verify` phase to the `deploy` phase in the Maven build lifecycle.

### 🧠 Why it matters
Running GPG signing during the `verify` phase caused build failures in CI environments where GPG keys are not available.  
By shifting it to the `deploy` phase, we ensure that signing only occurs during actual artifact publication, improving build stability and compatibility with GitHub Actions.

### ✅ Impact
- CI workflows can now run `mvn verify` without requiring GPG setup
- Artifact signing remains intact for deploy operations
- No changes to library functionality or public API

### 📌 Notes
This is an internal infrastructure change (`chore`) and does not affect consumers of the library.
