### PR TITLE
Add CI workflow to run tests on main and pull requests

### DIFF
--- a/.github/workflows/ci-test-execution.yml
+++ b/.github/workflows/ci-test-execution.yml
@@ -1,0 +1,28 @@
+name: CI - Test execution
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+
+      - name: Build and run tests with Maven
+        run: mvn clean verify -Dgpg.skip=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and uses [Semantic Versioning](https://semver.org/).
 ### [Unreleased]
 #### Chore
 - Move GPG signing to deploy phase to prevent CI failures
+- Add CI workflow to run tests on main and PRs
 
 ### [v1.0.0-alpha] - 2025-07-15
 #### Changed


### PR DESCRIPTION
### ✅ What was added
- GitHub Actions workflow to run `mvn verify` on every push and pull request to `main`
- Uses JDK 17 and caches Maven dependencies

### 🧪 Why it matters
This ensures that all code merged into `main` passes tests and builds correctly, improving stability and preventing regressions.

### 🔐 Notes
GPG signing is skipped during tests to avoid CI failures.
